### PR TITLE
Removal of duplicate IDs

### DIFF
--- a/docs/src/components/booster-layer.md
+++ b/docs/src/components/booster-layer.md
@@ -60,14 +60,14 @@ The buttons are interaction elements for the user with which he can make his cho
 Initially, all IDs except for `nuxt-booster-button-nojs` are set to `display: none;`.
 When an event is triggered, the relevant button is displayed via the ID using the style attribute `display: block;`.
 
-| ID                                                    | Description                                                                                                                                                       |
+| Selector                                                    | Description                                                                                                                                                       |
 | ----------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| <nobr>`nuxt-booster-button-init-nojs`</nobr>         | Visible when javascript is disabled, needed so that the user can hide the layer. Requires the [Hide Layer](/components/booster-layer#hide-layer) implementation. |
-| <nobr>`nuxt-booster-button-init-reduced-view`</nobr> | Is used to offer the user the possibility to visit the page only with activated fonts and images. Other initialisations of the Javascript are prevented.          |
-| <nobr>`nuxt-booster-button-init-app`</nobr>          | Activates all features. The initialisation of the JavaScript is started, images are loaded.                                                                       |
+| <nobr>`.nuxt-booster-button-init-nojs`</nobr>         | Visible when javascript is disabled, needed so that the user can hide the layer. Requires the [Hide Layer](/components/booster-layer#hide-layer) implementation. |
+| <nobr>`.nuxt-booster-button-init-reduced-view`</nobr> | Is used to offer the user the possibility to visit the page only with activated fonts and images. Other initialisations of the Javascript are prevented.          |
+| <nobr>`.nuxt-booster-button-init-app`</nobr>          | Activates all features. The initialisation of the JavaScript is started, images are loaded.                                                                       |
 
 ::: info
-It is recommended to register an **Inline Click-Event** for the buttons `#nuxt-booster-button-init-reduced-view` and `#nuxt-booster-button-init-app`.<br><br>More information under [Force App initialization](/components/booster-layer#force-app-initialization)
+It is recommended to register an **Inline Click-Event** for the buttons `.nuxt-booster-button-init-reduced-view` and `.nuxt-booster-button-init-app`.<br><br>More information under [Force App initialization](/components/booster-layer#force-app-initialization)
 :::
 
 ## Hide Layer
@@ -113,21 +113,21 @@ The layer can be closed via a `for` attribute with the `id` `nuxt-booster-layer-
     </ul>
 
     <!-- Button to hide the layer with no javascript -->
-    <button id="nuxt-booster-button-init-nojs">
+    <button class="nuxt-booster-button-init-nojs">
       <label for="nuxt-booster-layer-close">
         Apply without js
       </label>
     </button>
 
     <!-- Button for use without javascript and with fonts -->
-    <button id="nuxt-booster-button-init-reduced-view">
+    <button class="nuxt-booster-button-init-reduced-view">
       <label for="nuxt-booster-layer-close">
         Apply without scripts
       </label>
     </button>
 
     <!-- Button for activate javascript by bad connection or browser support -->
-    <button id="nuxt-booster-button-init-app">
+    <button class="nuxt-booster-button-init-app">
       Apply with all Features
     </button>
   </div>
@@ -136,11 +136,7 @@ The layer can be closed via a `for` attribute with the `id` `nuxt-booster-layer-
 
 ## Force App initialization
 
-For Unsupported-Browser and Insufficient Hardware events, an `onclick` event must also be set with the `id`.
-
-In the event, the global variable `__NUXT_BOOSTER_AUTO_INIT__` must be set to `true`.
-
-These are needed if the user has already reacted before the initial Javascript has been loaded. After the javascript has been successfully loaded, the app is automatically initialised.
+Set the global variable `__NUXT_BOOSTER_AUTO_INIT__` to `true` to force the initialization of the app.
 
 | Variable                      | Type      | Description                                                                  | Default |
 | ----------------------------- | --------- | ---------------------------------------------------------------------------- | ------- |

--- a/docs/src/components/weak-hardware-overlay.md
+++ b/docs/src/components/weak-hardware-overlay.md
@@ -7,10 +7,9 @@ title: WeakHardwareOverlay
 The `WeakHardwareOverlay` is used in components that are affected by the BoosterLayer event `Weak Hardware`. (*Example: Component requires the execution of `mounted` for functionality.*)
 
 ::: info
-The **performance issue event** occurs when initialization determines that the client is overloaded with execution and the user has confirmed the `#nuxt-booster-button-init-reduced-view` button in the BoosterLayer.
+The **performance issue event** occurs when initialization determines that the client is overloaded with execution and the user has confirmed the `.nuxt-booster-button-init-reduced-view` button in the BoosterLayer.
 
-- [Learn more about BoosterLayer interactions)](/components/booster-layer#buttons)
-
+[Learn more about BoosterLayer interactions)](/components/booster-layer#buttons)  
 :::
 
 Basically, the overlay is used to make content visible when the `Weak Hardware` has occurred, if this does not occur, the overlay is not visible.

--- a/docs/src/components/weak-hardware-overlay.md
+++ b/docs/src/components/weak-hardware-overlay.md
@@ -15,7 +15,7 @@ The **performance issue event** occurs when initialization determines that the c
 
 Basically, the overlay is used to make content visible when the `Weak Hardware` has occurred, if this does not occur, the overlay is not visible.
 
-It is recommended to include an interaction element in the overlay that allows the user to switch to the normal state. For this the interaction element must get the ID `nuxt-booster-button-init-app` and reacts on `click` with the initialization of the app.
+It is recommended to include an interaction element in the overlay that allows the user to switch to the normal state. For this the interaction element must get the Style Class `.nuxt-booster-button-init-app` and reacts on `click` with the initialization of the app.
 
 ## Example
 
@@ -29,7 +29,7 @@ Example of defining a custom `WeakHardwareOverlay` component and placing it in a
 <template>
   <booster-weak-hardware-overlay>
     To improve your experience, extensive features have been disabled.<br>
-    <button id="nuxt-booster-button-init-app">
+    <button class="nuxt-booster-button-init-app">
      Click here to enable them.
     </button>
   </booster-weak-hardware-overlay>

--- a/playground/components/InfoLayer.vue
+++ b/playground/components/InfoLayer.vue
@@ -58,19 +58,27 @@ defineOptions({ inheritAttrs: false });
     width: 100%;
     height: 100%;
     background-color: rgb(0 0 0 / 25%);
-    backdrop-filter: blur(em(7px));
+    backdrop-filter: blur(em(7));
     opacity: 0;
     animation-name: fade-in;
     animation-duration: 0.2s;
     animation-delay: 3s;
     animation-fill-mode: forwards;
 
+    & p {
+      margin: 0;
+    }
+
     & > div {
-      padding: 10px;
+      display: flex;
+      flex-direction: column;
+      gap: em(10);
+      align-items: center;
+      padding: em(20) em(10);
       color: #fff;
       text-align: center;
       background-color: rgb(0 0 0 / 60%);
-      box-shadow: 0 0 em(10px) rgb(0 0 0 / 60%);
+      box-shadow: 0 0 em(10) rgb(0 0 0 / 60%);
       transform: translateY(-100%);
       animation-name: fall-down;
       animation-duration: 0.2s;
@@ -96,10 +104,13 @@ ul {
 }
 
 .info-layer-buttons {
-  margin: em(10px) 0;
+  display: flex;
+  gap: em(15);
+  padding-top: em(10);
 
-  & > * {
-    margin: 0 em(5px);
+  @media (width <= 768px) {
+    flex-direction: column;
+    width: 100%;
   }
 }
 

--- a/playground/components/InfoLayer.vue
+++ b/playground/components/InfoLayer.vue
@@ -13,19 +13,17 @@
       </ul>
       <div class="info-layer-buttons">
         <base-button
-          id="nuxt-booster-button-init-nojs"
+          class="nuxt-booster-button-init-nojs"
           for="nuxt-booster-layer-close"
-        >
-          Yes
-        </base-button>
+          label="Yes"
+        />
         <base-button
-          id="nuxt-booster-button-init-reduced-view"
+          class="nuxt-booster-button-init-reduced-view"
           tag="label"
           for="nuxt-booster-layer-close"
-        >
-          No
-        </base-button>
-        <base-button id="nuxt-booster-button-init-app" label="Yes" />
+          label="No"
+        />
+        <base-button class="nuxt-booster-button-init-app" label="Yes" />
       </div>
     </div>
   </booster-layer>

--- a/playground/components/WeakHardwareOverlay.vue
+++ b/playground/components/WeakHardwareOverlay.vue
@@ -2,7 +2,7 @@
   <booster-weak-hardware-overlay>
     <div v-font="$getFont('Montserrat Alternates', 400, 'normal')">
       <p>{{ text }}</p>
-      <base-button id="nuxt-booster-button-init-app">
+      <base-button class="nuxt-booster-button-init-app">
         {{ buttonText }}
       </base-button>
     </div>

--- a/src/runtime/components/BoosterLayer.vue
+++ b/src/runtime/components/BoosterLayer.vue
@@ -54,7 +54,11 @@ onMounted(() => (isServer.value = false));
 useHead({
   noscript: [
     getStyleDescription(
-      `#nuxt-booster-layer button:not(#nuxt-booster-button-init-nojs) { display: none !important; } #nuxt-booster-button-nojs, #nuxt-booster-button-init-nojs, #nuxt-booster-message-nojs { display: initial !important; }`,
+      [
+        `#nuxt-booster-layer button:not(.nuxt-booster-button-init-nojs) { display: none !important; } .nuxt-booster-button-nojs, .nuxt-booster-button-init-nojs, #nuxt-booster-message-nojs { display: initial !important; }`,
+        // This is a temporary fix for the button display issue.
+        `#nuxt-booster-layer button:not(#nuxt-booster-button-init-nojs) { display: none !important; } #nuxt-booster-button-nojs, #nuxt-booster-button-init-nojs, #nuxt-booster-message-nojs { display: initial !important; }`
+      ].join(' '),
       true,
       'booster-layer'
     )

--- a/src/runtime/components/BoosterLayer.vue
+++ b/src/runtime/components/BoosterLayer.vue
@@ -78,6 +78,7 @@ useHead({
   display: none;
 }
 
+#nuxt-booster-button-init-nojs, /* id selector will removed in future */
 .nuxt-booster-button-init-nojs {
   display: none;
 }

--- a/src/runtime/components/BoosterLayer.vue
+++ b/src/runtime/components/BoosterLayer.vue
@@ -22,19 +22,19 @@
           </ul>
 
           <!-- Button to hide the layer with no javascript -->
-          <button id="nuxt-booster-button-init-nojs">
+          <button class="nuxt-booster-button-init-nojs">
             <label for="nuxt-booster-layer-close"> Apply without js </label>
           </button>
 
           <!-- Button for use without javascript and with fonts -->
-          <button id="nuxt-booster-button-init-reduced-view">
+          <button class="nuxt-booster-button-init-reduced-view">
             <label for="nuxt-booster-layer-close">
               Apply without scripts
             </label>
           </button>
 
           <!-- Button for activate javascript by bad connection or browser support -->
-          <button id="nuxt-booster-button-init-app">
+          <button class="nuxt-booster-button-init-app">
             Apply with all Features
           </button>
         </div>
@@ -78,7 +78,7 @@ useHead({
   display: none;
 }
 
-#nuxt-booster-button-init-nojs {
+.nuxt-booster-button-init-nojs {
   display: none;
 }
 

--- a/src/runtime/components/WeakHardwareOverlay.vue
+++ b/src/runtime/components/WeakHardwareOverlay.vue
@@ -2,7 +2,7 @@
   <div v-if="isServer" class="nuxt-booster-weak-hardware-overlay">
     <slot>
       Area is disabled for performance reasons.<br />
-      <button id="nuxt-booster-button-init-app">Click for activation</button>
+      <button class="nuxt-booster-button-init-app">Click for activation</button>
     </slot>
   </div>
 </template>

--- a/src/runtime/utils/entry.js
+++ b/src/runtime/utils/entry.js
@@ -5,17 +5,17 @@ export const triggerRunCallback = sufficient =>
     new CustomEvent('nuxt-booster:run', { detail: { sufficient } })
   );
 
-export function observeBoosterButton(id, callback) {
-  Array.from(document.querySelectorAll('#' + id)).forEach(el => {
+export const observeBoosterButton = (selector, callback) => {
+  Array.from(document.querySelectorAll(selector)).forEach(el => {
     el.addEventListener('click', callback, {
       capture: true,
       once: true,
       passive: true
     });
   });
-}
+};
 
-export function updateBoosterLayerMessage(layerEl, id) {
+export const updateBoosterLayerMessage = (layerEl, id) => {
   const el = window.document.getElementById(id);
   if (!el) {
     throw new Error("Can't update booster-layer, message " + id + ' missing.');
@@ -23,9 +23,9 @@ export function updateBoosterLayerMessage(layerEl, id) {
     el.style.display = 'block';
     layerEl.className += ' nuxt-booster-layer-visible';
   }
-}
+};
 
-export function setupBoosterLayer(layerEl, supportedBrowser) {
+export const setupBoosterLayer = (layerEl, supportedBrowser) => {
   if (!supportedBrowser) {
     updateBoosterLayerMessage('nuxt-booster-message-unsupported-browser');
   }
@@ -35,9 +35,9 @@ export function setupBoosterLayer(layerEl, supportedBrowser) {
       'nuxt-booster-message-reduced-bandwidth'
     );
   }
-}
+};
 
-export function initReducedView() {
+export const initReducedView = () => {
   document.documentElement.classList.add('nuxt-booster-reduced-view');
 
   // activate fonts
@@ -54,9 +54,9 @@ export function initReducedView() {
     el.parentNode.replaceChild(tmp.children[0], el);
     tmp.remove();
   });
-}
+};
 
-export async function hasBatteryPerformanceIssue(videoBlob) {
+export const hasBatteryPerformanceIssue = async videoBlob => {
   try {
     if (await isBatteryLow()) {
       throw new Error('Battery is low.');
@@ -67,7 +67,7 @@ export async function hasBatteryPerformanceIssue(videoBlob) {
     }
     await canVideoPlay(videoBlob);
   }
-}
+};
 
 /**
  * Checks if battery still has enough energy.
@@ -77,11 +77,11 @@ export async function hasBatteryPerformanceIssue(videoBlob) {
  * @see https://blog.google/products/chrome/new-chrome-features-to-save-battery-and-make-browsing-smoother/
  * @see https://developer.chrome.com/blog/memory-and-energy-saver-mode/
  **/
-async function isBatteryLow() {
+const isBatteryLow = async () => {
   const MIN_BATTERY_LEVEL = 0.2;
   const battery = await window.navigator.getBattery();
   return !battery.charging && battery.level <= MIN_BATTERY_LEVEL;
-}
+};
 
 /**
  * Checking whether a video can be played.
@@ -89,10 +89,10 @@ async function isBatteryLow() {
  *
  * In this case no video will be played automatically and play throws an error.
  */
-export function canVideoPlay(blob) {
+export const canVideoPlay = blob => {
   const video = document.createElement('video');
   video.muted = true;
   video.playsinline = true;
   video.src = URL.createObjectURL(blob);
   return video.play();
-}
+};

--- a/src/runtime/utils/entry.js
+++ b/src/runtime/utils/entry.js
@@ -96,3 +96,20 @@ export const canVideoPlay = blob => {
   video.src = URL.createObjectURL(blob);
   return video.play();
 };
+
+export const deprecationWarningButtonSelector = initApp => {
+  if (
+    document.querySelector(
+      '#nuxt-booster-button-init-nojs, #nuxt-booster-button-init-app, #nuxt-booster-button-init-reduced-view'
+    )
+  ) {
+    console.warn(
+      'The `#nuxt-booster-button-init-nojs`, `#nuxt-booster-button-init-reduced-view` and `#nuxt-booster-button-init-app` ids are deprecated. Please use the following classes instead: `.nuxt-booster-button-init-nojs`, `.nuxt-booster-button-init-reduced-view` and `.nuxt-booster-button-init-app`.'
+    );
+    observeBoosterButton(
+      '#nuxt-booster-button-init-reduced-view',
+      initReducedView
+    );
+    observeBoosterButton('#nuxt-booster-button-init-app', () => initApp(true));
+  }
+};

--- a/src/tmpl/entry.tmpl.js
+++ b/src/tmpl/entry.tmpl.js
@@ -2,7 +2,7 @@ export default options => {
   let code = `import { ${
     options.performanceCheck ? `run, ` : ``
   }hasSufficientPerformance, setup } from '#booster/utils/performance';
-import { triggerRunCallback, observeBoosterButton, setupBoosterLayer, updateBoosterLayerMessage, initReducedView, hasBatteryPerformanceIssue } from '#booster/utils/entry';
+import { triggerRunCallback, observeBoosterButton, setupBoosterLayer, updateBoosterLayerMessage, initReducedView, hasBatteryPerformanceIssue, deprecationWarningButtonSelector } from '#booster/utils/entry';
 import Deferred from '#booster/classes/Deferred';
 import { isSupportedBrowser } from '#booster/utils/browser';
 import {video as videoBlob} from './blobs.mjs';
@@ -125,6 +125,9 @@ if (!force) {
 
       observeBoosterButton('.nuxt-booster-button-init-reduced-view', initReducedView);
       observeBoosterButton('.nuxt-booster-button-init-app', () => initApp(true));
+
+      /* id selector will removed in future */
+      deprecationWarningButtonSelector(initApp);
 
       setup(${options.performanceMetrics});
 

--- a/src/tmpl/entry.tmpl.js
+++ b/src/tmpl/entry.tmpl.js
@@ -123,8 +123,8 @@ if (!force) {
       initApp(forceInit);
     } else {
 
-      observeBoosterButton('nuxt-booster-button-init-reduced-view', initReducedView);
-      observeBoosterButton('nuxt-booster-button-init-app', () => initApp(true));
+      observeBoosterButton('.nuxt-booster-button-init-reduced-view', initReducedView);
+      observeBoosterButton('.nuxt-booster-button-init-app', () => initApp(true));
 
       setup(${options.performanceMetrics});
 

--- a/test/tests/browser.js
+++ b/test/tests/browser.js
@@ -107,7 +107,7 @@ export default runtime => {
       ).not.toBeFalsy();
 
       await page.evaluate(() =>
-        document.getElementById('nuxt-booster-button-init-reduced-view').click()
+        document.querySelector('.nuxt-booster-button-init-reduced-view').click()
       );
       await page.waitForLoadState('networkidle');
 
@@ -128,7 +128,7 @@ export default runtime => {
       ).not.toBeFalsy();
 
       await page.evaluate(() =>
-        document.getElementById('nuxt-booster-button-init-app').click()
+        document.querySelector('.nuxt-booster-button-init-app').click()
       );
       await page.waitForLoadState('networkidle');
 
@@ -146,7 +146,7 @@ export default runtime => {
       ).not.toBeFalsy();
 
       await page.evaluate(() =>
-        document.getElementById('nuxt-booster-button-init-nojs').click()
+        document.querySelector('.nuxt-booster-button-init-nojs').click()
       );
 
       expect(


### PR DESCRIPTION
Fixing of duplicate Ids in the PageSpeed Insights accessibility check.

The interactive elements of the BoosterLayer are now used with a style class.
e.g. `#nuxt-booster-button-init-app` => `.nuxt-booster-button-init-app`