### PR TITLE
Feature/1289 property x does not exist on type createcomponentpublicinstancewithmixins

### DIFF
--- a/docs/src/guide/definitions.md
+++ b/docs/src/guide/definitions.md
@@ -309,7 +309,7 @@ declare module 'nuxt/app' {
 ### ComponentCustomProperties
 
 ```ts
-declare module '@vue/runtime-core' {
+declare module 'vue' {
   interface ComponentCustomProperties {
     $booster: {
       targetFormats: string[];

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -1,7 +1,6 @@
 import { defineNuxtConfig } from 'nuxt/config';
 import { readPackage } from 'read-pkg';
 import svgLoader from 'vite-svg-loader';
-import checker from 'vite-plugin-checker';
 
 import type { NuxtConfig } from '@nuxt/schema';
 import * as postcssFunctions from './postcss/functions';
@@ -68,9 +67,6 @@ export default defineNuxtConfig({
     plugins: [
       svgLoader({
         defaultImport: 'component' // or 'raw'
-      }),
-      checker({
-        vueTsc: true
       })
     ]
   },
@@ -417,6 +413,7 @@ export default defineNuxtConfig({
   modules: ['@nuxt/eslint', '../src/module'],
 
   typescript: {
+    typeCheck: true,
     tsConfig: {
       include: ['../../test/**/*.ts']
     }

--- a/src/types/module.ts
+++ b/src/types/module.ts
@@ -2,6 +2,7 @@ import type { Nuxt, ViteConfig } from 'nuxt/schema';
 import type { Manifest } from 'vue-bundle-renderer';
 import type { FontOption } from './font';
 import type { ImageModifiers } from '@nuxt/image';
+import type { Directive } from 'vue';
 
 export type HTMLCrossOriginAttribute = 'anonymous' | 'use-credentials' | '';
 export type CrossOrigin = boolean | HTMLCrossOriginAttribute | undefined;
@@ -154,7 +155,7 @@ declare module 'nuxt/app' {
   }
 }
 
-declare module '@vue/runtime-core' {
+declare module 'vue' {
   interface ComponentCustomProperties {
     $booster: {
       targetFormats: string[];


### PR DESCRIPTION
This pull request includes several updates to improve compatibility with the latest Vue and Nuxt versions, as well as some configuration adjustments. The most notable changes involve updating type declarations for Vue compatibility, modifying the Nuxt configuration to enable TypeScript type checking, and cleaning up unused dependencies.

### Updates for Vue Compatibility:

* Updated type declaration in `docs/src/guide/definitions.md` and `src/types/module.ts` to use `declare module 'vue'` instead of `declare module '@vue/runtime-core'` for `ComponentCustomProperties`, ensuring compatibility with the latest Vue versions. [[1]](diffhunk://#diff-dc6df826c453c05eeba5ac2452892780c2381f9a960720e70db96bda678b1136L312-R312) [[2]](diffhunk://#diff-28501dcb7eee92a000652f2b7ca69829547007adb50b00676c763def85d01dc4L157-R158)

### Nuxt Configuration Adjustments:

* Removed the `vite-plugin-checker` dependency and its associated configuration from `playground/nuxt.config.ts`, simplifying the build setup. [[1]](diffhunk://#diff-b6cfaa9b74f86caa4124f1680df8f08fba140cf3d9d5dbb38183ac5207781abdL4) [[2]](diffhunk://#diff-b6cfaa9b74f86caa4124f1680df8f08fba140cf3d9d5dbb38183ac5207781abdL71-L73)
* Enabled TypeScript type checking by setting `typescript.typeCheck` to `true` in `playground/nuxt.config.ts`, improving development reliability.

### Additional Type Enhancements:

* Added an import for the `Directive` type from Vue in `src/types/module.ts`, likely to support future functionality or improve type coverage.