### PR TITLE
feat: add `fetchpriority=high` to image preload elements

### DIFF
--- a/src/runtime/components/BoosterImage/classes/Source.ts
+++ b/src/runtime/components/BoosterImage/classes/Source.ts
@@ -97,7 +97,8 @@ export default class Source implements ISource {
       imagesrcset: srcset,
       imagesizes: sizes,
       media: this.media,
-      crossorigin: crossorigin as HTMLCrossOriginAttribute
+      crossorigin: crossorigin as HTMLCrossOriginAttribute,
+      fetchpriority: 'high'
     };
     return preload;
   }


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?**
Feature

* **What is the current behavior?**
Google recommends adding `fetchpriority="high"` to image-preload-tags (see [docs](https://web.dev/articles/optimize-lcp#1_eliminate_resource_load_delay)) and PageSpeed Insights will fail the `LCP request discovery` test, if it is not set. Currently this attribute is not set for `BoosterImage` and `BoosterPicture` instances with the `critical` prop.

* **What is the new behavior?**
This PR adds `fetchpriority="high"` to the `<link rel="preload" as="image">` elements.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.