### PR TITLE
fix: resolve promise `onerror` in addition to `onload` in `getImageSize`

### DIFF
--- a/src/runtime/utils/plugin.client.ts
+++ b/src/runtime/utils/plugin.client.ts
@@ -4,7 +4,8 @@ export async function getImageSize(src: string) {
   if (!dimensionCache.has(src)) {
     const { width, height } = (await new Promise(resolve => {
       let img: HTMLImageElement | undefined = new global.Image();
-      img.onload = () => {
+
+      const resolvePromise = () => {
         const dimension = {
           width: img?.naturalWidth || 0,
           height: img?.naturalHeight || 0
@@ -12,6 +13,9 @@ export async function getImageSize(src: string) {
         img = undefined;
         resolve(dimension);
       };
+
+      img.onload = () => resolvePromise();
+      img.onerror = () => resolvePromise();
       img.src = src;
     })) as { width: number; height: number };
     dimensionCache.set(src, { width, height });


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

When using `NuxtBooster` or `NuxtPicture` with non-existing images, client side JS-functionality seems to stop functioning.

The reason is, that in the `getImageSize` method of `src/runtime/utils/plugin.client.ts`, the promise only resolves, when the `onload` event is triggered. In case of a 404 image, this is never the case, halting client side JS processing. (As a result, `<NuxtLink>` does not work anymore, and `<ClientOnly>` content does not show.)

A reproduction of the problem is available here:
https://stackblitz.com/edit/nuxt-starter-j7mr6x5r?file=app.vue

* **What is the new behavior (if this is a feature change)?**

This PR makes it, that the promise is resolved in an `onerror`, as well as the `onload` event.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No.